### PR TITLE
Don't mutate passed in list of names

### DIFF
--- a/robin.js
+++ b/robin.js
@@ -8,6 +8,8 @@ module.exports = function (n, ps) {  // n = num players
     for (var k = 1; k <= n; k += 1) {
       ps.push(k);
     }
+  } else {
+    ps = ps.slice();
   }
 
   if (n % 2 === 1) {


### PR DESCRIPTION
Previously, the behavior of robin.js would mutate the original list of names passed into the function. 

Passing in ['a', 'b', 'c'], the original variable would be modified to end up ['a', 'b', 'c', -1, 'b'] or something like that. 

This change will prevent the original list of names from changing.
